### PR TITLE
Added installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Then add the following to `~/.emacs.d/init.el`:
 	(add-to-list 'load-path (expand-file-name "lisp/pollen-mode" user-emacs-directory))
     (autoload 'pollen-mode "pollen" "A major mode for the pollen preprocessor." t)
 	(add-to-list 'auto-mode-alist '("\\.pp\\'" . pollen-mode))
+	(add-to-list 'auto-mode-alist '("\\.pmd\\'" . pollen-mode))
+	(add-to-list 'auto-mode-alist '("\\.pm\\'" . pollen-mode))
+	(add-to-list 'auto-mode-alist '("\\.ptree\\'" . pollen-mode))
 
 Restart emacs. `pollen-mode` should activate when you open a file with
 a `.pp` extension.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ The code is based on Xah Lee's
 [Emacs Major Mode tutorial](http://ergoemacs.org/emacs/elisp_syntax_coloring.html)
 and the [Scribble Emacs mode](https://github.com/emacs-pe/scribble-mode).
 
+## Installation
+
+Download `pollen-mode` to your emacs lisp directory.
+
+    git clone https://github.com/basus/pollen-mode.git ~/.emacs.d/lisp/pollen-mode
+
+Then add the following to `~/.emacs.d/init.el`:
+
+	(add-to-list 'load-path (expand-file-name "lisp/pollen-mode" user-emacs-directory))
+    (autoload 'pollen-mode "pollen" "A major mode for the pollen preprocessor." t)
+	(add-to-list 'auto-mode-alist '("\\.pp\\'" . pollen-mode))
+
+Restart emacs. `pollen-mode` should activate when you open a file with
+a `.pp` extension.
+
 ## Syntax highlighting
 
 Currently the mode provides the following syntax highlighting using Emacs'


### PR DESCRIPTION
I added installation instructions based on the [EmacsWiki instructions for installing a major mode](http://www.emacswiki.org/emacs/AutoModeAlist). This will make it easier for people less experienced with emacs to use `pollen-mode`.
